### PR TITLE
Implement Protocol-Specific Filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Available options:
 - `--alert-port <PORT>`: Alert on traffic to/from specific port
 - `--log <filename>`: Enable logging to CSV file
 - `--interface <name>`: Specify network interface
+- `--protocol <TYPE>`: Filter by protocol (TCP, UDP, ICMP)
 - `--help`: Show help message
 
 ### Interactive Commands
@@ -96,6 +97,12 @@ While the program is running, you can use these commands:
 ### Monitor specific interface
 ```bash
 ./network2.0 --interface eth0 --log network_capture.csv
+```
+
+### Filter by protocol
+```bash
+./network2.0 --protocol TCP
+./network2.0 --protocol ICMP --log icmp_traffic.csv
 ```
 
 ## Output Interpretation

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -99,3 +99,16 @@ std::string Utils::getCurrentDateTime() {
     ss << std::put_time(std::localtime(&time_t), "%Y-%m-%d %H:%M:%S");
     return ss.str();
 }
+
+std::string Utils::toUpperCase(const std::string& str) {
+    std::string result = str;
+    for (char& c : result) {
+        c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+    }
+    return result;
+}
+
+bool Utils::isValidProtocol(const std::string& protocol) {
+    std::string upper = toUpperCase(protocol);
+    return (upper == "TCP" || upper == "UDP" || upper == "ICMP");
+}

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -26,6 +26,8 @@ namespace Utils {
     std::vector<std::string> splitString(const std::string& str, char delimiter);
     bool isValidIP(const std::string& ip);
     bool isValidPort(const std::string& port);
+    bool isValidProtocol(const std::string& protocol);
+    std::string toUpperCase(const std::string& str);
     std::string getCurrentDateTime();
 }
 


### PR DESCRIPTION
## 📌 Description

Adds a `--protocol <TYPE>` command-line flag that filters captured packets by protocol type (TCP, UDP, or ICMP). This allows users to focus on specific traffic types without being overwhelmed by all network activity.

### Changes Made

- **main.cpp**: Added `protocolFilter` member variable, `--protocol` argument parsing with validation, and filtering logic in `processPacket()` to skip non-matching packets
- **Utils.cpp/h**: Added `isValidProtocol()` and `toUpperCase()` helper functions for case-insensitive protocol validation
- **README.md**: Updated documentation with new flag and usage examples

### Usage

```bash
# Filter for TCP traffic only
./network2.0 --protocol TCP

# Filter for ICMP with logging
./network2.0 --protocol ICMP --log icmp_traffic.csv

# Combine with other options
./network2.0 --protocol UDP --watch-ip 192.168.1.100
```

---

## 🛠️ Technical Checklist
- [x] **Cross-Platform:** Tested on Linux? (No - Windows only)
- [x] **Cross-Platform:** Tested on Windows? (Yes)
- [x] **Sudo/Admin:** Verified packet capture works with privileges?
- [x] **Memory:** Checked for `libpcap` handle leaks?

---

## 🔗 Related Issue
Closes #1  (Implement Protocol-Specific Filtering)

---


### Help Text with New Flag
```
=== Network 2.0 v1.0 ===
Advanced packet capture and anomaly detection tool

Usage: network2.0 [OPTIONS]

Options:
  --help, -h              Show this help message
  --watch-ip <IP>         Watch traffic for specific IP address
  --alert-port <PORT>     Alert on traffic to/from specific port
  --log <filename>        Enable logging to CSV file
  --interface <name>      Specify network interface
  --protocol <TYPE>       Filter by protocol (TCP, UDP, ICMP)
```

### Invalid Protocol Rejection
```
Error: Invalid protocol 'INVALID'
Valid protocols: TCP, UDP, ICMP
```
