### PR TITLE
Fix compiler issue

### DIFF
--- a/src/AnomalyDetector.h
+++ b/src/AnomalyDetector.h
@@ -24,7 +24,7 @@ private:
     };
     
     struct ConnectionTracker {
-        int failedAttempts;
+        int failedAttempts = 0;
         std::chrono::system_clock::time_point firstFailTime;
         static const int FAILED_THRESHOLD = 20;
         static const int FAILED_WINDOW_SECONDS = 60;

--- a/src/PacketCapture.cpp
+++ b/src/PacketCapture.cpp
@@ -176,7 +176,7 @@ void PacketCapture::processRingBuffer() {
 
 /* ---------- Mostly same parsing logic ---------- */
 PacketInfo PacketCapture::parsePacket(
-    const struct pcap_pkthdr*,
+    const struct pcap_pkthdr* pkthdr,
     const u_char* packet) {
 
     PacketInfo info;

--- a/src/PacketCapture.h
+++ b/src/PacketCapture.h
@@ -28,7 +28,7 @@ private:
 
     // ===== RING BUFFER =====
     static const int RING_SIZE = 2048;   // bigger buffer for high speed
-    const u_char* ringBuffer[RING_SIZE];
+    // const u_char* ringBuffer[RING_SIZE]; Naming conflict. (see 7 line below)
 
     struct QueuedPacket {
         struct pcap_pkthdr header;


### PR DESCRIPTION
## 📌 Description

Current version on main branch does not compile.
I have fixed these 2 issues by commenting out a probably debrecated variable:
- const u_char* ringBuffer[RING_SIZE]; in PacketCapture.h
- const struct pcap_pkthdr* does not have a paramter name in PacketCapture::parsePacket

---

## 🛠️ Technical Checklist
- [ Yes] **Cross-Platform:** Tested on Linux? (Yes/No)
- [No ] **Cross-Platform:** Tested on Windows? (Yes/No)
- [yes ] **Sudo/Admin:** Verified packet capture works with privileges?
- [no ] **Memory:** Checked for `libpcap` handle leaks?

---

## 🔗 Related Issue
Closes #
None
---

## 📸 Screenshots
None